### PR TITLE
Distance measurement axis correction

### DIFF
--- a/src/plugins/DistanceMeasurementsPlugin/DistanceMeasurement.js
+++ b/src/plugins/DistanceMeasurementsPlugin/DistanceMeasurement.js
@@ -292,21 +292,21 @@ class DistanceMeasurement extends Component {
             this._zAxisLabelCulled = (zAxisCanvasLength < labelMinAxisLength);
 
             if (!this._xAxisLabelCulled) {
-                this._xAxisLabel.setText(Math.abs(this._targetWorld[0] - this._originWorld[0] * scale).toFixed(2) + unitAbbrev);
+                this._xAxisLabel.setText(Math.abs((this._targetWorld[0] - this._originWorld[0]) * scale).toFixed(2) + unitAbbrev);
                 this._xAxisLabel.setVisible(true);
             } else {
                 this._xAxisLabel.setVisible(false);
             }
 
             if (!this._yAxisLabelCulled) {
-                this._yAxisLabel.setText(Math.abs(this._targetWorld[1] - this._originWorld[1] * scale).toFixed(2) + unitAbbrev);
+                this._yAxisLabel.setText(Math.abs((this._targetWorld[1] - this._originWorld[1]) * scale).toFixed(2) + unitAbbrev);
                 this._yAxisLabel.setVisible(true);
             } else {
                 this._yAxisLabel.setVisible(false);
             }
 
             if (!this._zAxisLabelCulled) {
-                this._zAxisLabel.setText(Math.abs(this._targetWorld[2] - this._originWorld[2] * scale).toFixed(2) + unitAbbrev);
+                this._zAxisLabel.setText(Math.abs((this._targetWorld[2] - this._originWorld[2]) * scale).toFixed(2) + unitAbbrev);
                 this._zAxisLabel.setVisible(true);
             } else {
                 this._zAxisLabel.setVisible(false);


### PR DESCRIPTION
Scale: 1
![Screen Shot 2021-05-10 at 4 25 23 PM](https://user-images.githubusercontent.com/5697723/117736417-60b68e00-b1ac-11eb-85fe-1ee503de4d89.png)

Scale: 10
![Screen Shot 2021-05-10 at 4 25 29 PM](https://user-images.githubusercontent.com/5697723/117736414-5f856100-b1ac-11eb-9ea3-01ef7bf2fe7a.png)


Notice how only the length of the wire scales properly, but the axes do not. This fixes the calculation